### PR TITLE
added support for HDC1050 and HDC1080

### DIFF
--- a/Adafruit_HDC1000.cpp
+++ b/Adafruit_HDC1000.cpp
@@ -30,7 +30,8 @@ boolean Adafruit_HDC1000::begin(uint8_t addr) {
   
   reset();
   if (read16(HDC1000_MANUFID) != 0x5449) return false;
-  if (read16(HDC1000_DEVICEID) != 0x1000) return false;
+  uint16_t device_id = read16(HDC1000_DEVICEID);
+  if (device_id != 0x1000 && device_id != 0x1050) return false;
   return true;
 }
 


### PR DESCRIPTION
By default this library doesn't support the HDC1050 or HDC1080 because TI changed the device id from 0x1000 to 0x1050 with the introduction of the HDC1050.

According to the datasheets these sensors operate the same.

I added the 0x1050 device id for the HDC1050 and HDC1080 the device id check in `begin` (Adafruit_HDC1000.cpp:33-34).

I wasn't able to determine from the datasheet whether this will impact operation of the HDC1008 however I do not think that it will impact support for that sensor at all.

Unfortunately I dont have an HDC1050 or HDC1080 to test with, however in (max) a couple of weeks I should be able to run some tests as I have one in the mail.

Relevant datasheets:
https://www.ti.com/lit/ds/symlink/hdc1000.pdf
https://www.ti.com/lit/ds/symlink/hdc1050.pdf
https://www.ti.com/lit/ds/symlink/hdc1080.pdf